### PR TITLE
Fixed radix missing when not using new keyword

### DIFF
--- a/biginteger.js
+++ b/biginteger.js
@@ -85,7 +85,7 @@ function BigInteger(n, s, token) {
 		else if (typeof n === "undefined") {
 			return ZERO;
 		}
-		return BigInteger.parse(n);
+		return BigInteger.parse(n, s);
 	}
 
 	n = n || [];  // Provide the nullary constructor for subclasses.


### PR DESCRIPTION
The following code would throw `Bad digit for radix 10`

``` javascript
var num = BigInteger('f4c27e864920b848cc8ae46cb97fddd87bde7f58', 16);
```

Due to radix not being passed to parse function.
